### PR TITLE
fix: sheet config as any

### DIFF
--- a/src/flatfile/resources/sheets/types/sheet.py
+++ b/src/flatfile/resources/sheets/types/sheet.py
@@ -20,7 +20,7 @@ class Sheet(pydantic.BaseModel):
     id: SheetId
     workbook_id: WorkbookId = pydantic.Field(alias="workbookId")
     name: str
-    config: SheetConfig
+    config: typing.Any
     count_records: typing.Optional[RecordCounts] = pydantic.Field(alias="countRecords")
     namespace: typing.Optional[str]
     updated_at: dt.datetime = pydantic.Field(alias="updatedAt", description="Date the sheet was last updated")


### PR DESCRIPTION
It seems like much of this client is generated, but I wanted to share the fix we put in place to unblock using this client for reading sheet data. 

In particular we were attempting to read sheet data with the `flatfile_client.sheets.get()` method and were met with a number of pydantic `ValidationError`s. The minimal reproduction is reading in any sheet with a numeric field type which specifies a number of decimal places: 

```
{
          "key": "someNumber",
          "type": "number",
          "label": "Some Number",
          "config": {
            "decimalPlaces": 2
          }
}
```